### PR TITLE
Add International Domain Names (IDN) to test cases

### DIFF
--- a/test/shaaaaa.js
+++ b/test/shaaaaa.js
@@ -105,6 +105,28 @@ var sites = [
     intermediates: [
       {good: false, algorithm: "sha1"}
     ]
+  },
+  {
+    name: "Internationalized Domain, domaintest.みんな",
+    domain: "domaintest.xn--q9jyb4c",
+    diagnosis: "bad",
+
+    cert: {good: false, algorithm: "sha1"},
+    intermediates: [
+      {good: false, algorithm: "sha1"},
+      {good: false, algorithm: "sha1"}
+    ]
+  },
+  {
+    name: "Internationalized Domain, اختبارنطاق.شبكة",
+    domain: "xn--mgbaacjxy2c4fqb.xn--ngbc5azd",
+    diagnosis: "bad",
+
+    cert: {good: false, algorithm: "sha1"},
+    intermediates: [
+      {good: false, algorithm: "sha1"},
+      {good: false, algorithm: "sha1"}
+    ]
   }
 ];
 


### PR DESCRIPTION
After your recent regex commit @konklone I started thinking about other domain name cases that may need to be tested. I was using Google's Domain Test service (see https://github.com/google/domaintest) and international domain names seem like a good set of test cases to add. The two domains included are part of that suites gTLD list.

The current build works with the A-Label ASCII representation without issue:

```
➜  shaaaaaaaaaaaaa git:(master) ✗ ./bin/shaaaaaaaaaaaaa domaintest.xn--q9jyb4c 
{
  "domain": "domaintest.xn--q9jyb4c",
  "cert": {
    "algorithm": "sha1",
    "raw": "sha1WithRSAEncryption",
    "good": false,
    "expires": "2014-11-25T00:00:00.000Z",
    "name": "*.google.com"
  },
  "intermediates": [
    {
      "algorithm": "sha1",
      "raw": "sha1WithRSAEncryption",
      "good": false,
      "expires": "2015-04-04T15:15:55.000Z",
      "name": "Google Internet Authority G2"
    },
    {
      "algorithm": "sha1",
      "raw": "sha1WithRSAEncryption",
      "good": false,
      "expires": "2018-08-21T04:00:00.000Z",
      "name": "GeoTrust Global CA"
    }
  ],
  "diagnosis": "bad"
}
```

The only issue I've run into when running the cases with faucet is I sometimes get a gethostbyname failure (which I'm not sure if it's my flaky connection or something else). Thoughts/feedback appreciated.
