### PR TITLE
Update Gandi information

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -201,7 +201,7 @@
       <strong><a href="https://dnsimple.com/ssl-certificate">DNSimple</a></strong> has <a href="http://support.dnsimple.com/articles/sha-2-ssl-certificates/">now switched to SHA-2 certs by default</a>, so re-issue if you need to.
     </li>
     <li>
-      <strong><a href="http://www.gandi.net/support/contact/mail/">Gandi</a></strong> now <a href="https://twitter.com/gandibar/status/523250586750574592">uses SHA-2</a> for certificates expiring after January 1 2017.
+      <strong><a href="http://www.gandi.net/support/contact/mail/">Gandi</a></strong> now <a href="https://www.gandi.net/news/en/2014-10-21/2460-sha-2_certificates_are_now_available/">uses SHA-2</a> for certificates expiring after January 1 2017. For certificates requested until 2015 December 31 with an expiration date before 2017, you have to generate a CSR with SHA-2.
     </li>
   </ul>
 


### PR DESCRIPTION
Certs that expire before 2017 can now also get the magic SHA-2.
