### PR TITLE
Prevent adding known roots to tls connect response.

### DIFF
--- a/shaaaaa.js
+++ b/shaaaaa.js
@@ -104,7 +104,6 @@ var Shaaa = {
 
     var tlsOptions = {
       host: domain,
-      servername: domain,
       port: port,
       rejectUnauthorized: false
     };

--- a/shaaaaa.js
+++ b/shaaaaa.js
@@ -128,7 +128,7 @@ var Shaaa = {
           var pem = Shaaa.derToPem(peerCert.raw);
           if (pem) {
             certsArray.push(x509.parseCert(pem));
-            if (peerCert.issuerCertificate)
+            if (peerCert.issuerCertificate && (peerCert.issuerCertificate !== peerCert))
               peerCert = peerCert.issuerCertificate;
             else
               break; // no more depth levels


### PR DESCRIPTION
If 'ca' is omitted "well known" roots will be checked against (and added if found to be part of the chain).  But we don't want this.  We only want to see certs sent by the server itself.